### PR TITLE
fixed path response and form names

### DIFF
--- a/reserve.html
+++ b/reserve.html
@@ -31,25 +31,25 @@
     
 
                 <!-- Entry Form -->
-                <form>
+                <form action="/api/tables" method="post">
                     <div class="form-group">
                         <label for="">Name</label>
-                        <input type="text" class="form-control" id="NameInput">
+                        <input type="text" class="form-control" name="NameInput">
                     </div>
 
                     <div class="form-group">
                         <label for="">Phone Number</label>
-                        <input type="text" class="form-control" id="phoneNumberInput">
+                        <input type="text" class="form-control" name="phoneNumberInput">
                     </div>
 
                     <div class="form-group">
                         <label for="">EMAIL</label>
-                        <input type="text" class="form-control" id="emailInput">
+                        <input type="text" class="form-control" name="emailInput">
                     </div>
 
                     <div class="form-group">
                         <label for="">Unique ID</label>
-                        <input type="text" class="form-control" id="uniqueIDInput">
+                        <input type="text" class="form-control" name="uniqueIDInput">
                     </div>
                     
                     <button type="submit" class="btn btn-primary" id="addEmployeeBtn">Submit</button>

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ var bodyParser = require('body-parser');
 
 var app = express();
 var PORT = 3000;
+var path = require('path');
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
@@ -18,15 +19,15 @@ var waitList = [];
 
 // routes
 app.get('/', function(req, res) {
-	res.send(home.html);
-})
+	res.sendFile(path.join(__dirname + '/home.html'));
+});
 
 app.get('/reserve', function (req, res) {
-	res.send(reserve.html);
+	res.sendFile(path.join(__dirname + '/reserve.html'));
 });
 
 app.get('/tables', function (req, res) {
-	res.send(tables.html);
+	res.sendFile(path.join(__dirname + '/tables.html'));
 });
 
 // api routes


### PR DESCRIPTION
Changed res.send to res.sendFile for path get responses. Added path variable and path.join with path name to res.sendFile argument. Changed HTML attribute for form elements from 'id' to 'name' per Pavan.
